### PR TITLE
Some one PHP8.3 deprecation found and fixed

### DIFF
--- a/src/UserAgentParser.php
+++ b/src/UserAgentParser.php
@@ -251,7 +251,7 @@ class UserAgentParser
     private function explode($string, $delimiter)
     {
         $result = [];
-        while (($pos = strrpos($string, $delimiter)) !== false) {
+        while ($string && ($pos = strrpos($string, $delimiter)) !== false) {
             $result[] = ($string = substr($string, 0, $pos));
         }
         return $result;


### PR DESCRIPTION
E_DEPRECATED: strrpos(): Passing null to parameter #1 ($haystack) of type string is deprecated","context":{"code":8192,"message":"strrpos(): Passing null to parameter #1 ($haystack) of type string is deprecated","file":"/var/www/vendor/vipnytt/useragentparser/src/UserAgentParser.php","line":254